### PR TITLE
WEB-397:  Update Proton Web SDK some more

### DIFF
--- a/packages/proton-browser-transport/src/index.ts
+++ b/packages/proton-browser-transport/src/index.ts
@@ -23,7 +23,7 @@ interface footNoteDownloadLinks {
 }
 
 const footnoteLinks : footNoteDownloadLinks = {
-    proton: 'https://protonchain.com',
+    proton: 'https://protonchain.com/wallet',
     anchor: 'https://greymass.com/en/anchor/'
 }
 
@@ -94,7 +94,6 @@ export default class BrowserTransport implements LinkTransport {
                 text: '',
             })
             if (this.backButton) {
-                console.info('Use addEventListener("backToSelector", () => ...) to handle back event. See documentation for details: https://docs.protonchain.com/sdk/');
                 const backButton = this.createEl({class: 'back' })
                 backButton.onclick = (event) => {
                     event.stopPropagation()

--- a/packages/proton-browser-transport/src/index.ts
+++ b/packages/proton-browser-transport/src/index.ts
@@ -1,4 +1,4 @@
-import {LinkSession, LinkStorage, LinkTransport} from '@protonprotocol/proton-link'
+import {LinkSession, LinkTransport} from '@protonprotocol/proton-link'
 import {SigningRequest} from '@protonprotocol/proton-signing-request'
 import * as qrcode from 'qrcode'
 import styleSelector from './styles'
@@ -10,8 +10,6 @@ export interface BrowserTransportOptions {
     injectStyles?: boolean
     /** Whether to display request success and error messages, defaults to true */
     requestStatus?: boolean
-    /** Local storage prefix, defaults to `@protonprotocol/proton-link`. */
-    storagePrefix?: string
     /** Requesting account of the dapp (optional) */
     requestAccount?: string
     /** Wallet name e.g. proton, anchor, etc */
@@ -29,31 +27,11 @@ const footnoteLinks : footNoteDownloadLinks = {
     anchor: 'https://greymass.com/en/anchor/'
 }
 
-
-class Storage implements LinkStorage {
-    constructor(readonly keyPrefix: string) {}
-    async write(key: string, data: string): Promise<void> {
-        localStorage.setItem(this.storageKey(key), data)
-    }
-    async read(key: string): Promise<string | null> {
-        return localStorage.getItem(this.storageKey(key))
-    }
-    async remove(key: string): Promise<void> {
-        localStorage.removeItem(this.storageKey(key))
-    }
-    storageKey(key: string) {
-        return `${this.keyPrefix}-${key}`
-    }
-}
-
 export default class BrowserTransport implements LinkTransport {
-    storage: LinkStorage
-
     constructor(public readonly options: BrowserTransportOptions = {}) {
         this.classPrefix = options.classPrefix || 'proton-link'
         this.injectStyles = !(options.injectStyles === false)
         this.requestStatus = !(options.requestStatus === false)
-        this.storage = new Storage(options.storagePrefix || 'proton-link')
         this.requestAccount = options.requestAccount || ''
         this.walletType = options.walletType || 'proton'
         this.backButton = options.backButton || false

--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -559,8 +559,11 @@ export class Link implements esr.AbiProvider {
         let key = this.sessionKey(identifier, formatAuth(auth))
         await this.storage.remove(key)
         await this.touchSession(identifier, auth, true)
-        if (this.storage.read('wallet-type')) {
+        if (await this.storage.read('wallet-type')) {
             this.storage.remove('wallet-type')
+        }
+        if (await this.storage.read('user-auth')) {
+            this.storage.remove('user-auth')
         }
     }
 

--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -135,7 +135,7 @@ export class Link implements esr.AbiProvider {
         this.serviceAddress = (options.service || defaults.service).trim().replace(/\/$/, '')
         this.transport = options.transport
         if (options.storage !== null) {
-            this.storage = options.storage || this.transport.storage
+            this.storage = options.storage
         }
         this.requestOptions = {
             abiProvider: this,

--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -464,7 +464,7 @@ export class Link implements esr.AbiProvider {
 
         // once successfully logged in, set wallet type so restore session can work properly
         if (this.walletType.length > 0) {
-            localStorage.setItem('browser-transport-wallet-type', this.walletType)
+            this.storage!.write('wallet-type', this.walletType)
         }
 
         return {
@@ -559,8 +559,8 @@ export class Link implements esr.AbiProvider {
         let key = this.sessionKey(identifier, formatAuth(auth))
         await this.storage.remove(key)
         await this.touchSession(identifier, auth, true)
-        if (localStorage.getItem('browser-transport-wallet-type')) {
-            localStorage.removeItem('browser-transport-wallet-type')
+        if (this.storage.read('wallet-type')) {
+            this.storage.remove('wallet-type')
         }
     }
 

--- a/packages/proton-web-sdk/src/index.ts
+++ b/packages/proton-web-sdk/src/index.ts
@@ -1,5 +1,5 @@
 import ProtonLinkBrowserTransport, { BrowserTransportOptions } from '@protonprotocol/proton-browser-transport'
-import ProtonLink, { LinkOptions, LinkStorage } from '@protonprotocol/proton-link'
+import ProtonLink, { LinkOptions, LinkStorage, PermissionLevel } from '@protonprotocol/proton-link'
 import { JsonRpc } from '@protonprotocol/protonjs'
 import SupportedWallets from './supported-wallets'
 
@@ -26,7 +26,8 @@ interface ConnectWalletArgs {
         endpoints?: string | string[],
         rpc?: JsonRpc,
         storage?: LinkStorage,
-        storagePrefix?: string
+        storagePrefix?: string,
+        restoreSession?: boolean
     },
     transportOptions?: BrowserTransportOptions;
     selectorOptions?: {
@@ -59,58 +60,102 @@ export const ConnectWallet = async ({
     }
 
     // Default showSelector to true
-    if (!selectorOptions.showSelector) {
+    if (selectorOptions.showSelector !== false) {
         selectorOptions.showSelector = true
     }
 
-    // Create Modal Class
-    const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo)
-
-    // Determine wallet type from storage or selector modal
-    let walletType = selectorOptions.walletType
-    if (!walletType) {
-        const storedWalletType = localStorage.getItem('browser-transport-wallet-type')
-        if (storedWalletType) {
-            walletType = storedWalletType
-        } else if (selectorOptions.showSelector) {
-            walletType = await wallets.displayWalletSelector()
-        } else {
-            throw new Error('Wallet Type Unavailable: No walletType provided and showSelector is set to false')
+    // Stop restore session if no saved data
+    if (linkOptions.restoreSession) {
+        const savedUserAuth = await linkOptions.storage.read('user-auth')
+        const walletType = await linkOptions.storage.read('wallet-type')
+        if (!savedUserAuth || !walletType) {
+            // clean storage to remove unexpected side effects if session restore fails
+            linkOptions.storage.remove('wallet-type')
+            linkOptions.storage.remove('user-auth')
+            return { link: null, session: null }
         }
     }
 
-    // Set scheme (proton default)
-    switch (walletType) {
-        case 'anchor':
-            linkOptions.scheme = 'esr'
-            break
-        case 'proton': {
-            // Proton Testnet
-            if (linkOptions.chainId === '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd') {
-                linkOptions.scheme = 'proton-dev'
+    let session, link
+
+    while(!session) {
+        // Create Modal Class
+        const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo)
+
+        // Determine wallet type from storage or selector modal
+        let walletType = selectorOptions.walletType
+        if (!walletType) {
+            const storedWalletType = await linkOptions.storage.read('wallet-type')
+            if (storedWalletType) {
+                walletType = storedWalletType
+            } else if (selectorOptions.showSelector) {
+                walletType = await wallets.displayWalletSelector()
             } else {
-                linkOptions.scheme = 'proton'
+                try {
+                    throw new Error('Wallet Type Unavailable: No walletType provided and showSelector is set to false')
+                } catch (e) {
+                    console.error(e)
+                }
             }
-            break;
         }
-        default:
-            linkOptions.scheme = 'proton'
-            break
+
+        // Set scheme (proton default)
+        switch (walletType) {
+            case 'anchor':
+                linkOptions.scheme = 'esr'
+                break
+            case 'proton': {
+                // Proton Testnet
+                if (linkOptions.chainId === '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd') {
+                    linkOptions.scheme = 'proton-dev'
+                } else {
+                    linkOptions.scheme = 'proton'
+                }
+                break;
+            }
+            default:
+                linkOptions.scheme = 'proton'
+                break
+        }
+
+        // Create transport
+        const transport = new ProtonLinkBrowserTransport({
+            ...transportOptions,
+            walletType
+        })
+
+        // Create link
+        link = new ProtonLink({
+            ...linkOptions,
+            transport,
+            walletType
+        })
+
+        // Get session based on login or restore session
+        if (!linkOptions.restoreSession) {
+            let backToSelector = false
+            document.addEventListener('backToSelector', () => {backToSelector = true})
+            try {
+                const loginResult = await link.login(transportOptions.requestAccount || '')
+                session = loginResult.session
+                linkOptions.storage.write('user-auth', JSON.stringify(session.auth))
+            } catch(e) {
+                if (backToSelector) {
+                    document.removeEventListener('backToSelector', () => {backToSelector = true})
+                    continue
+                }
+                return e
+            }
+        } else {
+            const stringifiedUserAuth = await linkOptions.storage.read('user-auth')
+            const parsedUserAuth = stringifiedUserAuth ? JSON.parse(stringifiedUserAuth) : {}
+            const savedUserAuth : PermissionLevel = Object.keys(parsedUserAuth).length > 0 ? parsedUserAuth : null
+            if (savedUserAuth) {
+                session = await link.restoreSession(transportOptions.requestAccount || '', savedUserAuth)
+            }
+        }
     }
 
-    // Create transport
-    const transport = new ProtonLinkBrowserTransport({
-        ...transportOptions,
-        walletType
-    })
-
-    // Create link
-    const link = new ProtonLink({
-        ...linkOptions,
-        transport,
-        walletType
-    })
-
-    // Return link
-    return link
+    // Return link, session
+    return { link, session }
 }


### PR DESCRIPTION
Bring login/restore session functionality into web-sdk so frontend implementation is simpler.
Back button is now purely from web-sdk, so frontend implementation is no longer necessary
Previous local storage usage has now been transferred to link-storage. 
Added storage and storage-prefix as parameters to linkOptions so devs can input their own storage as desired. 
Session restore is now being implemented through a parameter in linkOptions rather than it being called through link.restoreSession().
