### PR TITLE
WEB-418: Remaining key after logout in local storage

### DIFF
--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -645,7 +645,11 @@ export class Link implements esr.AbiProvider {
             auths.unshift(auth)
         }
         let key = this.sessionKey(identifier, 'list')
-        await this.storage!.write(key, JSON.stringify(auths))
+        if (remove === true) {
+            await this.storage!.remove(key)
+        } else {
+            await this.storage!.write(key, JSON.stringify(auths))
+        }
     }
 
     /** Makes sure session is in storage list of sessions and moves it to top (most recently used). */

--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -641,13 +641,11 @@ export class Link implements esr.AbiProvider {
         if (existing >= 0) {
             auths.splice(existing, 1)
         }
-        if (remove === false) {
-            auths.unshift(auth)
-        }
         let key = this.sessionKey(identifier, 'list')
         if (remove === true) {
             await this.storage!.remove(key)
         } else {
+            auths.unshift(auth)
             await this.storage!.write(key, JSON.stringify(auths))
         }
     }


### PR DESCRIPTION
remove session key instead of replacing with empty array on logout