### PR TITLE
Fix ArrayBuffer conversion

### DIFF
--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -709,6 +709,8 @@ function waitForCallback(url: string, ctx: {cancel?: () => void}) {
                 } else {
                     if (typeof event.data === 'string') {
                         handleResponse(event.data)
+                    } else if (event.data instanceof ArrayBuffer) {
+                        handleResponse(Buffer.from(event.data).toString())
                     } else {
                         handleResponse(event.data.toString())
                     }


### PR DESCRIPTION
This PR fixes the issue when the websocket's event.data is an ArrayBuffer instead of a string.

