### PR TITLE
WEB-457: Add custom style options for modal selector

### DIFF
--- a/packages/proton-test-app/src/components/HelloWorld.vue
+++ b/packages/proton-test-app/src/components/HelloWorld.vue
@@ -39,7 +39,19 @@ export default {
         },
         selectorOptions: {
           appName: 'Taskly',
-          appLogo: 'https://taskly.protonchain.com/static/media/taskly-logo.ad0bfb0f.svg'
+          appLogo: 'https://taskly.protonchain.com/static/media/taskly-logo.ad0bfb0f.svg',
+          modalBackgroundColor: 'pink',
+          optionBackgroundColor: 'white',
+          customStyles: {
+            modalBackgroundColor: '#F4F7FA',
+            logoBackgroundColor: 'white',
+            isLogoRound: true,
+            optionBackgroundColor: 'white',
+            optionFontColor: 'black',
+            primaryFontColor: 'black',
+            secondaryFontColor: '#6B727F',
+            linkColor: '#752EEB'
+          }
         }
       })
       this.link = link

--- a/packages/proton-test-app/src/components/HelloWorld.vue
+++ b/packages/proton-test-app/src/components/HelloWorld.vue
@@ -42,7 +42,7 @@ export default {
           appLogo: 'https://taskly.protonchain.com/static/media/taskly-logo.ad0bfb0f.svg',
           modalBackgroundColor: 'pink',
           optionBackgroundColor: 'white',
-          customStyles: {
+          customStyleOptions: {
             modalBackgroundColor: '#F4F7FA',
             logoBackgroundColor: 'white',
             isLogoRound: true,

--- a/packages/proton-web-sdk/README.md
+++ b/packages/proton-web-sdk/README.md
@@ -29,6 +29,16 @@ const link = await ConnectWallet({
     selectorOptions: {
         appName: 'Taskly', /* Optional: Name to show in modal, Default 'app' */
         appLogo: 'https://protondemos.com/static/media/taskly-logo.ad0bfb0f.svg', /* Optional: Logo to show in modal */
+        customStyles: { /* Optional: Custom styles for modal */
+            modalBackgroundColor: '#F4F7FA',
+            logoBackgroundColor: 'white',
+            isLogoRound: true,
+            optionBackgroundColor: 'white',
+            optionFontColor: 'black',
+            primaryFontColor: 'black',
+            secondaryFontColor: '#6B727F',
+            linkColor: '#752EEB'
+        }
         // walletType: 'proton' /* Optional: Connect to only specified wallet (e.g. 'proton', 'anchor') */
     }
 })

--- a/packages/proton-web-sdk/README.md
+++ b/packages/proton-web-sdk/README.md
@@ -29,7 +29,7 @@ const link = await ConnectWallet({
     selectorOptions: {
         appName: 'Taskly', /* Optional: Name to show in modal, Default 'app' */
         appLogo: 'https://protondemos.com/static/media/taskly-logo.ad0bfb0f.svg', /* Optional: Logo to show in modal */
-        customStyles: { /* Optional: Custom styles for modal */
+        customStyleOptions: { /* Optional: Custom style options for modal */
             modalBackgroundColor: '#F4F7FA',
             logoBackgroundColor: 'white',
             isLogoRound: true,

--- a/packages/proton-web-sdk/src/index.ts
+++ b/packages/proton-web-sdk/src/index.ts
@@ -21,6 +21,17 @@ class Storage implements LinkStorage {
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
+export interface SelectorCustomStyles {
+    modalBackgroundColor?: string,
+    logoBackgroundColor?: string,
+    isLogoRound?: boolean,
+    optionBackgroundColor?: string,
+    optionFontColor?: string,
+    primaryFontColor?: string,
+    secondaryFontColor?: string,
+    linkColor?: string,
+}
+
 interface ConnectWalletArgs {
     linkOptions: PartialBy<LinkOptions, 'transport'> & {
         endpoints?: string | string[],
@@ -34,6 +45,7 @@ interface ConnectWalletArgs {
         appName?: string,
         appLogo?: string,
         walletType?: string
+        customStyles?: SelectorCustomStyles
     }
 }
 
@@ -74,7 +86,7 @@ export const ConnectWallet = async ({
 
     while(!session) {
         // Create Modal Class
-        const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo)
+        const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo, selectorOptions.customStyles)
 
         // Determine wallet type from storage or selector modal
         let walletType = selectorOptions.walletType

--- a/packages/proton-web-sdk/src/index.ts
+++ b/packages/proton-web-sdk/src/index.ts
@@ -21,7 +21,7 @@ class Storage implements LinkStorage {
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
-export interface SelectorCustomStyles {
+export interface CustomStyleOptions {
     modalBackgroundColor?: string,
     logoBackgroundColor?: string,
     isLogoRound?: boolean,
@@ -45,7 +45,7 @@ interface ConnectWalletArgs {
         appName?: string,
         appLogo?: string,
         walletType?: string
-        customStyles?: SelectorCustomStyles
+        customStyleOptions?: CustomStyleOptions
     }
 }
 
@@ -86,7 +86,7 @@ export const ConnectWallet = async ({
 
     while(!session) {
         // Create Modal Class
-        const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo, selectorOptions.customStyles)
+        const wallets = new SupportedWallets(selectorOptions.appName, selectorOptions.appLogo, selectorOptions.customStyleOptions)
 
         // Determine wallet type from storage or selector modal
         let walletType = selectorOptions.walletType

--- a/packages/proton-web-sdk/src/styles.ts
+++ b/packages/proton-web-sdk/src/styles.ts
@@ -176,5 +176,5 @@ export default `
     color: rgb(0, 170, 239);
     text-decoration: none;
 }
-.
+
 `

--- a/packages/proton-web-sdk/src/styles.ts
+++ b/packages/proton-web-sdk/src/styles.ts
@@ -1,180 +1,201 @@
 /* I do not see any ttf files for fonts, so assuming they need to be added (marking as TODO for later) */
-export default `
-.wallet-selector * {
-    box-sizing: border-box;
-    line-height: 1;
-}
+import { CustomStyleOptions } from './index';
 
-.wallet-selector {
-    font-family: 'Circular Std Book', -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-        Arial, sans-serif;
-    font-size: 13px;
-    background: rgba(0, 0, 0, 0.65);
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    width: 100%;
-    height: 100%;
-    z-index: 2147483647;
-    display: none;
-    align-items: center;
-    justify-content: center;
-}
+export default (customStyleOptions: CustomStyleOptions | undefined): string => {
+    return `
+    .wallet-selector * {
+        box-sizing: border-box;
+        line-height: 1;
+    }
 
-.wallet-selector-active {
-    display: flex;
-}
+    .wallet-selector {
+        font-family: 'Circular Std Book', -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+            Arial, sans-serif;
+        font-size: 13px;
+        background: rgba(0, 0, 0, 0.65);
+        position: fixed;
+        top: 0px;
+        left: 0px;
+        width: 100%;
+        height: 100%;
+        z-index: 2147483647;
+        display: none;
+        align-items: center;
+        justify-content: center;
+    }
 
-.wallet-selector-inner {
-    background: #ffffff;
-    color: white;
-    margin: 20px;
-    padding-top: 50px;
-    border-radius: 10px;
-    box-shadow: 0px 4px 100px rgba(0, 0, 0, .5);
-    width: 360px;
-    transition-property: all;
-    transition-duration: .5s;
-    transition-timing-function: ease-in-out;
-    position: relative;
-}
+    .wallet-selector-active {
+        display: flex;
+    }
 
-.wallet-selector-close {
-    display: block;
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    width: 28px;
-    height: 28px;
-    background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.66 10.987L6 7.327l-3.66 3.66A1.035 1.035 0 11.876 9.523l3.66-3.66-3.66-3.66A1.035 1.035 0 012.34.737L6 4.398 9.66.739a1.035 1.035 0 111.464 1.464l-3.66 3.66 3.66 3.661a1.035 1.035 0 11-1.464 1.464z' fill='rgba(161, 165, 176, 0.7)' fill-rule='nonzero'/%3E%3C/svg%3E");
-    background-size: 14px;
-    background-repeat: no-repeat;
-    background-position: 50%;
-    cursor: pointer;
-    transition: background-image 0.2s ease;
-}
+    .wallet-selector-inner {
+        background: ${customStyleOptions && customStyleOptions.modalBackgroundColor ? customStyleOptions.modalBackgroundColor : '#ffffff'};
+        color: white;
+        margin: 20px;
+        padding-top: 50px;
+        border-radius: 10px;
+        box-shadow: 0px 4px 100px rgba(0, 0, 0, .5);
+        width: 360px;
+        transition-property: all;
+        transition-duration: .5s;
+        transition-timing-function: ease-in-out;
+        position: relative;
+    }
 
-.wallet-selector-close:hover {
-    background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.66 10.987L6 7.327l-3.66 3.66A1.035 1.035 0 11.876 9.523l3.66-3.66-3.66-3.66A1.035 1.035 0 012.34.737L6 4.398 9.66.739a1.035 1.035 0 111.464 1.464l-3.66 3.66 3.66 3.661a1.035 1.035 0 11-1.464 1.464z' fill='rgba(161, 165, 176, 1)' fill-rule='nonzero'/%3E%3C/svg%3E");
-    transition: background-image 0.2s ease;
-}
+    .wallet-selector-close {
+        display: block;
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        width: 28px;
+        height: 28px;
+        background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.66 10.987L6 7.327l-3.66 3.66A1.035 1.035 0 11.876 9.523l3.66-3.66-3.66-3.66A1.035 1.035 0 012.34.737L6 4.398 9.66.739a1.035 1.035 0 111.464 1.464l-3.66 3.66 3.66 3.661a1.035 1.035 0 11-1.464 1.464z' fill='rgba(161, 165, 176, 0.7)' fill-rule='nonzero'/%3E%3C/svg%3E");
+        background-size: 14px;
+        background-repeat: no-repeat;
+        background-position: 50%;
+        cursor: pointer;
+        transition: background-image 0.2s ease;
+    }
 
-.wallet-selector-connect {
-    padding: 0px 20px;
-    border-radius: 10px;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    background: #ffffff;
-}
+    .wallet-selector-close:hover {
+        background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.66 10.987L6 7.327l-3.66 3.66A1.035 1.035 0 11.876 9.523l3.66-3.66-3.66-3.66A1.035 1.035 0 012.34.737L6 4.398 9.66.739a1.035 1.035 0 111.464 1.464l-3.66 3.66 3.66 3.661a1.035 1.035 0 11-1.464 1.464z' fill='rgba(161, 165, 176, 1)' fill-rule='nonzero'/%3E%3C/svg%3E");
+        transition: background-image 0.2s ease;
+    }
 
-.wallet-selector-connect-header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
+    .wallet-selector-connect {
+        padding: 0px 20px;
+        border-radius: 10px;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        background: ${customStyleOptions && customStyleOptions.modalBackgroundColor ? customStyleOptions.modalBackgroundColor : '#ffffff'};
+    }
 
-.wallet-selector-logo {
-    width: 100px;
-    height: 100px;
-}
+    .wallet-selector-connect-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
 
-.wallet-selector-title {
-    font-size: 16px;
-    font-family: 'Circular Std Book', sans-serif;
-    line-height: 24px;
-    color: black;
-    text-align: center;
-}
+    .wallet-selector-logo {
+        width: 100px;
+        height: 100px;
 
-.wallet-selector-subtitle {
-    font-size: 16px;
-    font-family: 'Circular Std Book', sans-serif;
-    line-height: 24px;
-    color: #a1a5b0;
-    text-align: center;
-}
+        ${customStyleOptions && customStyleOptions.logoBackgroundColor && `
+            background: ${customStyleOptions.logoBackgroundColor};
+            ${customStyleOptions.isLogoRound && `
+            width: 120px;
+            height: 120px;
+            padding: 10px;
+            margin-bottom: 10px;
+            border: 1px solid rgba(161, 165, 176, 0.23);
+            border-radius: 50%;
+            `}
+        `}
+    }
 
-.wallet-selector-connect-body {
-    margin-top: 55px;
-}
+    .wallet-selector-title {
+        font-size: 16px;
+        font-family: 'Circular Std Book', sans-serif;
+        line-height: 24px;
+        color: ${customStyleOptions && customStyleOptions.primaryFontColor ? customStyleOptions.primaryFontColor : 'black'};
+        text-align: center;
+    }
 
-.wallet-selector-wallet-list {
-    margin: 0px;
-    padding: 0px;
-    list-style: none;
-}
+    .wallet-selector-subtitle {
+        font-size: 16px;
+        font-family: 'Circular Std Book', sans-serif;
+        line-height: 24px;
+        color: ${customStyleOptions && customStyleOptions.secondaryFontColor ? customStyleOptions.secondaryFontColor : '#a1a5b0'};
+        text-align: center;
+    }
 
-.wallet-selector-proton-wallet, .wallet-selector-anchor-wallet {
-    display: flex;
-    align-items: center;
-    padding: 20px 20px 20px 16px;
-    border: 1px solid rgba(161, 165, 176, 0.23);
-}
+    .wallet-selector-connect-body {
+        margin-top: 55px;
+    }
 
-.wallet-selector-anchor-wallet {
-    margin-top: 8px;
-}
+    .wallet-selector-wallet-list {
+        margin: 0px;
+        padding: 0px;
+        list-style: none;
+    }
 
-.wallet-selector-proton-wallet:hover, .wallet-selector-anchor-wallet:hover {
-    cursor: pointer;
-}
+    ${customStyleOptions && customStyleOptions.optionBackgroundColor && `
+    .wallet-selector-wallet-list li {
+        background: ${customStyleOptions.optionBackgroundColor};
+    }
+    `}
 
-.wallet-selector-proton-logo {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cdefs%3E%3ClinearGradient id='8h6tugcn1a' x1='4.068%25' x2='97.224%25' y1='97.082%25' y2='127.413%25'%3E%3Cstop offset='0%25' stop-color='%237543E3'/%3E%3Cstop offset='100%25' stop-color='%23582ACB'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cg transform='translate(-365 -412) translate(332 136) translate(16 256) translate(17 20)'%3E%3Ccircle cx='20' cy='20' r='20' fill='url(%238h6tugcn1a)' fill-rule='nonzero'/%3E%3Cpath fill='%23FFF' d='M20.501 6c1.798 0 3.35 1.864 4.37 4.892-.412.115-.833.243-1.259.385-.849-2.505-2.013-3.979-3.11-3.979-1.238 0-2.558 1.87-3.417 4.977.335.108.675.223 1.02.35.78.287 1.584.624 2.404 1.007l.14-.066c.526-.241 1.048-.464 1.565-.668l.185-.072c1.548-.597 3.043-1.026 4.411-1.252 2.948-.49 5.02.017 5.834 1.426.815 1.41.22 3.455-1.679 5.758-.11.131-.22.265-.338.396-.282-.313-.583-.626-.904-.94 1.675-1.94 2.334-3.634 1.796-4.565-.51-.88-2.188-1.177-4.495-.795-.493.081-1.005.192-1.531.329.075.345.145.697.207 1.061.142.816.252 1.68.33 2.578.406.285.802.574 1.182.868 1.49 1.151 2.769 2.358 3.753 3.552 1.898 2.303 2.494 4.349 1.68 5.758-.612 1.059-1.934 1.608-3.804 1.608-.619 0-1.297-.06-2.03-.182-.19-.032-.383-.067-.578-.106.117-.402.225-.823.323-1.259.158.032.314.06.468.085 2.305.382 3.986.086 4.495-.795.618-1.07-.348-3.151-2.62-5.453-.226.207-.46.413-.701.617l-.108.089c-.643.538-1.333 1.065-2.062 1.578-.036.407-.076.81-.124 1.2-.71 5.704-2.797 9.618-5.403 9.618-1.794 0-3.343-1.858-4.364-4.879.41-.11.83-.24 1.26-.385.848 2.497 2.008 3.966 3.104 3.966 1.238 0 2.56-1.876 3.421-4.992-.337-.107-.678-.221-1.021-.348-.785-.286-1.586-.62-2.392-.992l-.052.024c-.455.211-.903.408-1.345.59-.069.027-.136.055-.202.079-2.545 1.024-4.868 1.554-6.716 1.554-1.84 0-3.206-.527-3.837-1.617-.903-1.561-.049-3.848 2.089-6.258l.908.957c-1.729 1.976-2.416 3.708-1.87 4.652.618 1.069 2.9 1.275 6.024.465-.073-.344-.143-.695-.205-1.058-.141-.815-.251-1.676-.33-2.573-.407-.284-.803-.572-1.178-.86C10.173 19.544 8 16.59 8 14.391c0-.508.117-.976.357-1.391.899-1.552 3.285-1.962 6.418-1.335-.118.408-.228.834-.327 1.276-2.576-.508-4.42-.236-4.964.708-.618 1.069.344 3.145 2.609 5.443.29-.263.592-.524.909-.783.61-.504 1.27-1.004 1.973-1.496.036-.408.076-.811.125-1.202C15.81 9.913 17.897 6 20.501 6zm4.114 18.122c-.313.198-.63.393-.953.584l-.328.191c-.385.22-.77.434-1.15.634l-.169.088c.395.167.788.323 1.176.467.35.13.696.25 1.039.361.076-.355.147-.722.21-1.101.067-.394.123-.805.175-1.224zm-8.232-.002c.055.44.118.867.188 1.28.062.36.13.708.204 1.046.21-.068.422-.14.638-.216.065-.022.132-.046.197-.07.443-.16.898-.336 1.363-.534l.013-.005c-.44-.23-.88-.472-1.317-.724l-.069-.04c-.418-.242-.821-.488-1.217-.737zm4.119-9.05c-.445.216-.89.442-1.336.684-.282.152-.565.31-.847.472-.74.427-1.437.865-2.094 1.308-.026.378-.05.761-.064 1.155-.017.428-.024.866-.024 1.311 0 .854.031 1.675.087 2.465.38.256.77.51 1.177.76.3.185.604.369.918.549.727.418 1.457.804 2.184 1.156l.14-.066c.482-.238.97-.493 1.467-.768.191-.104.382-.211.574-.322.74-.427 1.436-.864 2.093-1.307.027-.379.05-.763.065-1.156.016-.428.024-.866.024-1.311 0-.853-.032-1.675-.087-2.465-.379-.255-.768-.509-1.176-.76-.3-.185-.606-.367-.92-.549-.74-.426-1.468-.81-2.181-1.157zm0 3.261c.923 0 1.67.747 1.67 1.669s-.747 1.669-1.67 1.669c-.924 0-1.672-.747-1.672-1.669s.748-1.669 1.671-1.669zm5.635.174c.019.49.029.988.029 1.495 0 .122 0 .245-.002.367-.004.383-.015.76-.03 1.134.335-.253.656-.506.962-.76.04-.03.077-.06.114-.092.26-.217.508-.433.747-.65-.219-.196-.446-.394-.682-.592-.359-.303-.74-.603-1.138-.902zM14.869 18.5c-.301.227-.592.454-.87.681-.335.272-.653.545-.955.819.22.197.447.396.684.594.358.3.74.601 1.138.9-.02-.49-.03-.988-.03-1.495 0-.122 0-.245.004-.365.003-.383.014-.76.029-1.134zm9.359-4.948c-.173.057-.347.115-.523.176-.516.178-1.04.38-1.571.602l-.113.049c.435.229.873.47 1.313.723l.068.04c.416.24.82.487 1.217.738-.054-.44-.117-.868-.188-1.28-.062-.361-.13-.709-.203-1.048zm-7.454 0c-.076.355-.146.72-.21 1.1-.068.393-.125.804-.177 1.222.397-.25.804-.496 1.223-.739l.059-.033c.438-.253.879-.493 1.319-.723-.399-.168-.79-.324-1.174-.466-.355-.133-.7-.251-1.04-.36z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
-}
+    .wallet-selector-proton-wallet, .wallet-selector-anchor-wallet {
+        display: flex;
+        align-items: center;
+        padding: 20px 20px 20px 16px;
+        border: 1px solid rgba(161, 165, 176, 0.23);
+    }
 
-.wallet-selector-anchor-logo {
-    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgc3R5bGU9IiIgdHJhbnNmb3JtPSJtYXRyaXgoMC45LCAwLCAwLCAwLjksIDEyLjc5OTk5NSwgMTIuNzk5OTk1KSI+CiAgICA8Y2lyY2xlIGN4PSIxMjgiIGN5PSIxMjgiIHI9IjEyOCIgZmlsbD0iIzM2NTBBMiIgc3R5bGU9IiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0gMTI4LjAxIDQ4IEMgMTMxLjY4OSA0OCAxMzUuMDQ0IDUwLjEwMiAxMzYuNjQ3IDUzLjQxMiBMIDE3NS4wNTcgMTMyLjYxMyBMIDE3NS45MjQgMTM0LjQgTCAxNTQuNTg3IDEzNC40IEwgMTQ4LjM3OCAxMjEuNiBMIDEwNy42NCAxMjEuNiBMIDEwMS40MzMgMTM0LjQgTCA4MC4wOTQgMTM0LjQgTCA4MC45NjMgMTMyLjYxMSBMIDExOS4zNzIgNTMuNDEyIEMgMTIwLjk3OCA1MC4xMDIgMTI0LjMzMSA0OCAxMjguMDEgNDggWiBNIDExNS40IDEwNS42MDEgTCAxNDAuNjE5IDEwNS42MDEgTCAxMjguMDEgNzkuNjAxIEwgMTE1LjQgMTA1LjYwMSBaIE0gMTU2Ljc5OCAxNjEuNiBMIDE3Ni4wMDggMTYxLjYgQyAxNzUuNDMgMTg3LjQ0MyAxNTQuMDM5IDIwOCAxMjguMDEgMjA4IEMgMTAxLjk4MyAyMDggODAuNTg5IDE4Ny40NDMgODAuMDEyIDE2MS42IEwgOTkuMjIgMTYxLjYgQyA5OS42NzEgMTczLjM2NyAxMDcuNDg5IDE4My40MDkgMTE4LjM5OSAxODcuMTk1IEwgMTE4LjM5OSAxNDguODAxIEMgMTE4LjM5OSAxNDMuNDk5IDEyMi42OTggMTM5LjIgMTI4IDEzOS4yIEMgMTMzLjMwMiAxMzkuMiAxMzcuNjAxIDE0My40OTkgMTM3LjYwMSAxNDguODAxIEwgMTM3LjYwMSAxODcuMjAxIEMgMTQ4LjUyMiAxODMuNDIxIDE1Ni4zNDkgMTczLjM3NiAxNTYuNzk4IDE2MS42IFoiIGZpbGw9IndoaXRlIiBzdHlsZT0iIi8+CiAgPC9nPgo8L3N2Zz4=");
-}
+    .wallet-selector-anchor-wallet {
+        margin-top: 8px;
+    }
 
-.wallet-selector-proton-logo,
-.wallet-selector-anchor-logo {
-    width: 40px;
-    height: 40px;
-    background-size: 40px;
-    background-repeat: no-repeat;
-    background-position: 50%;
-}
+    .wallet-selector-proton-wallet:hover, .wallet-selector-anchor-wallet:hover {
+        cursor: pointer;
+    }
 
-.wallet-selector-wallet-name {
-    font-family: 'Circular Std Book', sans-serif;
-    font-size: 16px;
-    line-height: 24px;
-    color: #000531;
-    margin-left: 20px;
-}
+    .wallet-selector-proton-logo {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cdefs%3E%3ClinearGradient id='8h6tugcn1a' x1='4.068%25' x2='97.224%25' y1='97.082%25' y2='127.413%25'%3E%3Cstop offset='0%25' stop-color='%237543E3'/%3E%3Cstop offset='100%25' stop-color='%23582ACB'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg%3E%3Cg%3E%3Cg%3E%3Cg transform='translate(-365 -412) translate(332 136) translate(16 256) translate(17 20)'%3E%3Ccircle cx='20' cy='20' r='20' fill='url(%238h6tugcn1a)' fill-rule='nonzero'/%3E%3Cpath fill='%23FFF' d='M20.501 6c1.798 0 3.35 1.864 4.37 4.892-.412.115-.833.243-1.259.385-.849-2.505-2.013-3.979-3.11-3.979-1.238 0-2.558 1.87-3.417 4.977.335.108.675.223 1.02.35.78.287 1.584.624 2.404 1.007l.14-.066c.526-.241 1.048-.464 1.565-.668l.185-.072c1.548-.597 3.043-1.026 4.411-1.252 2.948-.49 5.02.017 5.834 1.426.815 1.41.22 3.455-1.679 5.758-.11.131-.22.265-.338.396-.282-.313-.583-.626-.904-.94 1.675-1.94 2.334-3.634 1.796-4.565-.51-.88-2.188-1.177-4.495-.795-.493.081-1.005.192-1.531.329.075.345.145.697.207 1.061.142.816.252 1.68.33 2.578.406.285.802.574 1.182.868 1.49 1.151 2.769 2.358 3.753 3.552 1.898 2.303 2.494 4.349 1.68 5.758-.612 1.059-1.934 1.608-3.804 1.608-.619 0-1.297-.06-2.03-.182-.19-.032-.383-.067-.578-.106.117-.402.225-.823.323-1.259.158.032.314.06.468.085 2.305.382 3.986.086 4.495-.795.618-1.07-.348-3.151-2.62-5.453-.226.207-.46.413-.701.617l-.108.089c-.643.538-1.333 1.065-2.062 1.578-.036.407-.076.81-.124 1.2-.71 5.704-2.797 9.618-5.403 9.618-1.794 0-3.343-1.858-4.364-4.879.41-.11.83-.24 1.26-.385.848 2.497 2.008 3.966 3.104 3.966 1.238 0 2.56-1.876 3.421-4.992-.337-.107-.678-.221-1.021-.348-.785-.286-1.586-.62-2.392-.992l-.052.024c-.455.211-.903.408-1.345.59-.069.027-.136.055-.202.079-2.545 1.024-4.868 1.554-6.716 1.554-1.84 0-3.206-.527-3.837-1.617-.903-1.561-.049-3.848 2.089-6.258l.908.957c-1.729 1.976-2.416 3.708-1.87 4.652.618 1.069 2.9 1.275 6.024.465-.073-.344-.143-.695-.205-1.058-.141-.815-.251-1.676-.33-2.573-.407-.284-.803-.572-1.178-.86C10.173 19.544 8 16.59 8 14.391c0-.508.117-.976.357-1.391.899-1.552 3.285-1.962 6.418-1.335-.118.408-.228.834-.327 1.276-2.576-.508-4.42-.236-4.964.708-.618 1.069.344 3.145 2.609 5.443.29-.263.592-.524.909-.783.61-.504 1.27-1.004 1.973-1.496.036-.408.076-.811.125-1.202C15.81 9.913 17.897 6 20.501 6zm4.114 18.122c-.313.198-.63.393-.953.584l-.328.191c-.385.22-.77.434-1.15.634l-.169.088c.395.167.788.323 1.176.467.35.13.696.25 1.039.361.076-.355.147-.722.21-1.101.067-.394.123-.805.175-1.224zm-8.232-.002c.055.44.118.867.188 1.28.062.36.13.708.204 1.046.21-.068.422-.14.638-.216.065-.022.132-.046.197-.07.443-.16.898-.336 1.363-.534l.013-.005c-.44-.23-.88-.472-1.317-.724l-.069-.04c-.418-.242-.821-.488-1.217-.737zm4.119-9.05c-.445.216-.89.442-1.336.684-.282.152-.565.31-.847.472-.74.427-1.437.865-2.094 1.308-.026.378-.05.761-.064 1.155-.017.428-.024.866-.024 1.311 0 .854.031 1.675.087 2.465.38.256.77.51 1.177.76.3.185.604.369.918.549.727.418 1.457.804 2.184 1.156l.14-.066c.482-.238.97-.493 1.467-.768.191-.104.382-.211.574-.322.74-.427 1.436-.864 2.093-1.307.027-.379.05-.763.065-1.156.016-.428.024-.866.024-1.311 0-.853-.032-1.675-.087-2.465-.379-.255-.768-.509-1.176-.76-.3-.185-.606-.367-.92-.549-.74-.426-1.468-.81-2.181-1.157zm0 3.261c.923 0 1.67.747 1.67 1.669s-.747 1.669-1.67 1.669c-.924 0-1.672-.747-1.672-1.669s.748-1.669 1.671-1.669zm5.635.174c.019.49.029.988.029 1.495 0 .122 0 .245-.002.367-.004.383-.015.76-.03 1.134.335-.253.656-.506.962-.76.04-.03.077-.06.114-.092.26-.217.508-.433.747-.65-.219-.196-.446-.394-.682-.592-.359-.303-.74-.603-1.138-.902zM14.869 18.5c-.301.227-.592.454-.87.681-.335.272-.653.545-.955.819.22.197.447.396.684.594.358.3.74.601 1.138.9-.02-.49-.03-.988-.03-1.495 0-.122 0-.245.004-.365.003-.383.014-.76.029-1.134zm9.359-4.948c-.173.057-.347.115-.523.176-.516.178-1.04.38-1.571.602l-.113.049c.435.229.873.47 1.313.723l.068.04c.416.24.82.487 1.217.738-.054-.44-.117-.868-.188-1.28-.062-.361-.13-.709-.203-1.048zm-7.454 0c-.076.355-.146.72-.21 1.1-.068.393-.125.804-.177 1.222.397-.25.804-.496 1.223-.739l.059-.033c.438-.253.879-.493 1.319-.723-.399-.168-.79-.324-1.174-.466-.355-.133-.7-.251-1.04-.36z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+    }
 
-.wallet-selector-right-arrow {
-    background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 0.7)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
-    width: 10px;
-    height: 20px;
-    background-size: 10px;
-    background-repeat: no-repeat;
-    background-position: 50%;
-    margin-left: auto;
-}
+    .wallet-selector-anchor-logo {
+        background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgc3R5bGU9IiIgdHJhbnNmb3JtPSJtYXRyaXgoMC45LCAwLCAwLCAwLjksIDEyLjc5OTk5NSwgMTIuNzk5OTk1KSI+CiAgICA8Y2lyY2xlIGN4PSIxMjgiIGN5PSIxMjgiIHI9IjEyOCIgZmlsbD0iIzM2NTBBMiIgc3R5bGU9IiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0gMTI4LjAxIDQ4IEMgMTMxLjY4OSA0OCAxMzUuMDQ0IDUwLjEwMiAxMzYuNjQ3IDUzLjQxMiBMIDE3NS4wNTcgMTMyLjYxMyBMIDE3NS45MjQgMTM0LjQgTCAxNTQuNTg3IDEzNC40IEwgMTQ4LjM3OCAxMjEuNiBMIDEwNy42NCAxMjEuNiBMIDEwMS40MzMgMTM0LjQgTCA4MC4wOTQgMTM0LjQgTCA4MC45NjMgMTMyLjYxMSBMIDExOS4zNzIgNTMuNDEyIEMgMTIwLjk3OCA1MC4xMDIgMTI0LjMzMSA0OCAxMjguMDEgNDggWiBNIDExNS40IDEwNS42MDEgTCAxNDAuNjE5IDEwNS42MDEgTCAxMjguMDEgNzkuNjAxIEwgMTE1LjQgMTA1LjYwMSBaIE0gMTU2Ljc5OCAxNjEuNiBMIDE3Ni4wMDggMTYxLjYgQyAxNzUuNDMgMTg3LjQ0MyAxNTQuMDM5IDIwOCAxMjguMDEgMjA4IEMgMTAxLjk4MyAyMDggODAuNTg5IDE4Ny40NDMgODAuMDEyIDE2MS42IEwgOTkuMjIgMTYxLjYgQyA5OS42NzEgMTczLjM2NyAxMDcuNDg5IDE4My40MDkgMTE4LjM5OSAxODcuMTk1IEwgMTE4LjM5OSAxNDguODAxIEMgMTE4LjM5OSAxNDMuNDk5IDEyMi42OTggMTM5LjIgMTI4IDEzOS4yIEMgMTMzLjMwMiAxMzkuMiAxMzcuNjAxIDE0My40OTkgMTM3LjYwMSAxNDguODAxIEwgMTM3LjYwMSAxODcuMjAxIEMgMTQ4LjUyMiAxODMuNDIxIDE1Ni4zNDkgMTczLjM3NiAxNTYuNzk4IDE2MS42IFoiIGZpbGw9IndoaXRlIiBzdHlsZT0iIi8+CiAgPC9nPgo8L3N2Zz4=");
+    }
 
-.wallet-selector-proton-wallet:hover .wallet-selector-right-arrow {
-    background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 1)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
-}
+    .wallet-selector-proton-logo,
+    .wallet-selector-anchor-logo {
+        width: 40px;
+        height: 40px;
+        background-size: 40px;
+        background-repeat: no-repeat;
+        background-position: 50%;
+    }
 
-.wallet-selector-anchor-wallet:hover .wallet-selector-right-arrow {
-    background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 1)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
-}
+    .wallet-selector-wallet-name {
+        font-family: 'Circular Std Book', sans-serif;
+        font-size: 16px;
+        line-height: 24px;
+        color: ${customStyleOptions && customStyleOptions.optionFontColor ? customStyleOptions.optionFontColor : '#000531'};
+        margin-left: 20px;
+    }
 
-.wallet-selector-tos-agreement {
-    font-family: 'Circular Std Book', sans-serif;
-    font-size: 12px;
-    line-height: 16px;
-    color: rgb(161, 165, 176);
-    text-align: center;
-    margin-top: 55px;
-    margin-bottom: 30px;
-}
+    .wallet-selector-right-arrow {
+        background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 0.7)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
+        width: 10px;
+        height: 20px;
+        background-size: 10px;
+        background-repeat: no-repeat;
+        background-position: 50%;
+        margin-left: auto;
+    }
 
-.wallet-selector-tos-link {
-    color: rgb(0, 170, 239);
-    text-decoration: none;
-}
+    .wallet-selector-proton-wallet:hover .wallet-selector-right-arrow {
+        background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 1)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
+    }
 
-`
+    .wallet-selector-anchor-wallet:hover .wallet-selector-right-arrow {
+        background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='chevron-right' class='svg-inline--fa fa-chevron-right fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='rgba(161, 165, 176, 1)' d='M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z'%3E%3C/path%3E%3C/svg%3E");
+    }
+
+    .wallet-selector-tos-agreement {
+        font-family: 'Circular Std Book', sans-serif;
+        font-size: 12px;
+        line-height: 16px;
+        text-align: center;
+        margin-top: 55px;
+        margin-bottom: 30px;
+        color: ${customStyleOptions && customStyleOptions.secondaryFontColor ? customStyleOptions.secondaryFontColor : 'rgb(161, 165, 176)'};
+    }
+
+    .wallet-selector-tos-link {
+        color: ${customStyleOptions && customStyleOptions.linkColor ? customStyleOptions.linkColor : 'rgb(0, 170, 239)'};
+        text-decoration: none;
+    }
+    `
+}

--- a/packages/proton-web-sdk/src/styles.ts
+++ b/packages/proton-web-sdk/src/styles.ts
@@ -2,6 +2,28 @@
 import { CustomStyleOptions } from './index';
 
 export default (customStyleOptions: CustomStyleOptions | undefined): string => {
+    const defaultOptions = {
+        modalBackgroundColor: '#ffffff',
+        logoBackgroundColor: 'transparent',
+        isLogoRound: false,
+        optionBackgroundColor: 'transparent',
+        optionFontColor: '#000531',
+        primaryFontColor: 'black',
+        secondaryFontColor: '#a1a5b0',
+        linkColor: '#00AAEF',
+    };
+
+    const {
+        modalBackgroundColor,
+        logoBackgroundColor,
+        isLogoRound,
+        optionBackgroundColor,
+        optionFontColor,
+        primaryFontColor,
+        secondaryFontColor,
+        linkColor,
+    } = Object.assign(defaultOptions, customStyleOptions);
+
     return `
     .wallet-selector * {
         box-sizing: border-box;
@@ -29,7 +51,7 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
     }
 
     .wallet-selector-inner {
-        background: ${customStyleOptions && customStyleOptions.modalBackgroundColor ? customStyleOptions.modalBackgroundColor : '#ffffff'};
+        background: ${modalBackgroundColor};
         color: white;
         margin: 20px;
         padding-top: 50px;
@@ -67,7 +89,7 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         border-radius: 10px;
         border-top-left-radius: 0;
         border-top-right-radius: 0;
-        background: ${customStyleOptions && customStyleOptions.modalBackgroundColor ? customStyleOptions.modalBackgroundColor : '#ffffff'};
+        background: ${modalBackgroundColor};
     }
 
     .wallet-selector-connect-header {
@@ -79,17 +101,14 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
     .wallet-selector-logo {
         width: 100px;
         height: 100px;
-
-        ${customStyleOptions && customStyleOptions.logoBackgroundColor && `
-            background: ${customStyleOptions.logoBackgroundColor};
-            ${customStyleOptions.isLogoRound && `
-            width: 120px;
-            height: 120px;
-            padding: 10px;
-            margin-bottom: 10px;
-            border: 1px solid rgba(161, 165, 176, 0.23);
-            border-radius: 50%;
-            `}
+        background: ${logoBackgroundColor};
+        ${isLogoRound && `
+        width: 120px;
+        height: 120px;
+        padding: 10px;
+        margin-bottom: 10px;
+        border: 1px solid rgba(161, 165, 176, 0.23);
+        border-radius: 50%;
         `}
     }
 
@@ -97,7 +116,7 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         font-size: 16px;
         font-family: 'Circular Std Book', sans-serif;
         line-height: 24px;
-        color: ${customStyleOptions && customStyleOptions.primaryFontColor ? customStyleOptions.primaryFontColor : 'black'};
+        color: ${primaryFontColor};
         text-align: center;
     }
 
@@ -105,7 +124,7 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         font-size: 16px;
         font-family: 'Circular Std Book', sans-serif;
         line-height: 24px;
-        color: ${customStyleOptions && customStyleOptions.secondaryFontColor ? customStyleOptions.secondaryFontColor : '#a1a5b0'};
+        color: ${secondaryFontColor};
         text-align: center;
     }
 
@@ -119,11 +138,9 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         list-style: none;
     }
 
-    ${customStyleOptions && customStyleOptions.optionBackgroundColor && `
     .wallet-selector-wallet-list li {
-        background: ${customStyleOptions.optionBackgroundColor};
+        background: ${optionBackgroundColor};
     }
-    `}
 
     .wallet-selector-proton-wallet, .wallet-selector-anchor-wallet {
         display: flex;
@@ -161,7 +178,7 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         font-family: 'Circular Std Book', sans-serif;
         font-size: 16px;
         line-height: 24px;
-        color: ${customStyleOptions && customStyleOptions.optionFontColor ? customStyleOptions.optionFontColor : '#000531'};
+        color: ${optionFontColor};
         margin-left: 20px;
     }
 
@@ -190,11 +207,11 @@ export default (customStyleOptions: CustomStyleOptions | undefined): string => {
         text-align: center;
         margin-top: 55px;
         margin-bottom: 30px;
-        color: ${customStyleOptions && customStyleOptions.secondaryFontColor ? customStyleOptions.secondaryFontColor : 'rgb(161, 165, 176)'};
+        color: ${secondaryFontColor};
     }
 
     .wallet-selector-tos-link {
-        color: ${customStyleOptions && customStyleOptions.linkColor ? customStyleOptions.linkColor : 'rgb(0, 170, 239)'};
+        color: ${linkColor};
         text-decoration: none;
     }
     `

--- a/packages/proton-web-sdk/src/supported-wallets.ts
+++ b/packages/proton-web-sdk/src/supported-wallets.ts
@@ -1,16 +1,16 @@
 import styleText from './styles'
-import { SelectorCustomStyles } from './index'
+import { CustomStyleOptions } from './index'
 
 export default class SupportedWallets {
-    constructor(public readonly name?: string, logo?: string, customStyles?: SelectorCustomStyles) {
+    constructor(public readonly name?: string, logo?: string, customStyleOptions?: CustomStyleOptions) {
         this.appLogo = logo
         this.appName = name || 'app'
-        this.customStyles = customStyles;
+        this.customStyleOptions = customStyleOptions;
     }
 
     private appLogo: string | undefined
     private appName: string
-    private customStyles: SelectorCustomStyles | undefined
+    private customStyleOptions: CustomStyleOptions | undefined
 
     /** Container and stylesheet for Wallet Selector */
     private selectorContainerEl!: HTMLElement
@@ -189,7 +189,7 @@ export default class SupportedWallets {
     }
 
     private getCustomStyleText(): string {
-        if (!this.customStyles) return ''
+        if (!this.customStyleOptions) return ''
         const {
             modalBackgroundColor,
             logoBackgroundColor,
@@ -199,7 +199,7 @@ export default class SupportedWallets {
             primaryFontColor,
             secondaryFontColor,
             linkColor
-        } = this.customStyles
+        } = this.customStyleOptions
 
         return `        
         ${modalBackgroundColor && `

--- a/packages/proton-web-sdk/src/supported-wallets.ts
+++ b/packages/proton-web-sdk/src/supported-wallets.ts
@@ -1,4 +1,4 @@
-import styleText from './styles'
+import getStyleText from './styles'
 import { CustomStyleOptions } from './index'
 
 export default class SupportedWallets {
@@ -37,8 +37,8 @@ export default class SupportedWallets {
         this.styleEl = document.createElement('style')
         this.styleEl.type = 'text/css'
 
-        const customStyleText = this.getCustomStyleText()
-        this.styleEl.appendChild(document.createTextNode(styleText + customStyleText))
+        const styleText = getStyleText(this.customStyleOptions)
+        this.styleEl.appendChild(document.createTextNode(styleText))
         this.styleEl.appendChild(this.font)
         document.head.appendChild(this.styleEl)
 
@@ -186,80 +186,6 @@ export default class SupportedWallets {
             this.selectorEl.appendChild(body)
             this.showSelector()
         })
-    }
-
-    private getCustomStyleText(): string {
-        if (!this.customStyleOptions) return ''
-        const {
-            modalBackgroundColor,
-            logoBackgroundColor,
-            isLogoRound,
-            optionBackgroundColor,
-            optionFontColor,
-            primaryFontColor,
-            secondaryFontColor,
-            linkColor
-        } = this.customStyleOptions
-
-        return `        
-        ${modalBackgroundColor && `
-        .wallet-selector-inner {
-            background: ${modalBackgroundColor};
-        }
-
-        .wallet-selector-connect {
-            background: ${modalBackgroundColor};
-        }
-        `}
-
-        ${logoBackgroundColor && `
-        .wallet-selector-logo {
-            background: ${logoBackgroundColor};
-            ${isLogoRound && `
-            width: 120px;
-            height: 120px;
-            padding: 10px;
-            margin-bottom: 10px;
-            border: 1px solid rgba(161, 165, 176, 0.23);
-            border-radius: 50%;
-            `}
-        }
-        `}
-
-        ${optionBackgroundColor && `
-        .wallet-selector-wallet-list li {
-            background: ${optionBackgroundColor};
-        }
-        `}
-
-        ${optionFontColor && `
-        .wallet-selector-wallet-name {
-            color: ${optionFontColor};
-        }
-        `}
-
-        ${primaryFontColor && `
-        .wallet-selector-title {
-            color: ${primaryFontColor};
-        }
-        `}
-
-        ${secondaryFontColor && `
-        .wallet-selector-subtitle {
-            color: ${secondaryFontColor};
-        }
-
-        .wallet-selector-tos-agreement {
-            color: ${secondaryFontColor};
-        }
-        `}
-
-        ${linkColor && `
-        .wallet-selector-tos-link {
-            color: ${linkColor};
-        }
-        `}
-        `
     }
 }
 

--- a/packages/proton-web-sdk/src/supported-wallets.ts
+++ b/packages/proton-web-sdk/src/supported-wallets.ts
@@ -1,13 +1,16 @@
 import styleText from './styles'
+import { SelectorCustomStyles } from './index'
 
 export default class SupportedWallets {
-    constructor(public readonly name?: string, logo?: string) {
+    constructor(public readonly name?: string, logo?: string, customStyles?: SelectorCustomStyles) {
         this.appLogo = logo
         this.appName = name || 'app'
+        this.customStyles = customStyles;
     }
 
     private appLogo: string | undefined
     private appName: string
+    private customStyles: SelectorCustomStyles | undefined
 
     /** Container and stylesheet for Wallet Selector */
     private selectorContainerEl!: HTMLElement
@@ -179,8 +182,84 @@ export default class SupportedWallets {
 
             this.selectorEl.appendChild(header)
             this.selectorEl.appendChild(body)
+            this.setCustomStyles()
             this.showSelector()
         })
+    }
+
+    private getAllTypecastElementsByClassName(className: string): HTMLElement[] {
+        return Array.from(document.getElementsByClassName(className) as HTMLCollectionOf<HTMLElement>)
+    }
+
+    private getTypecastElementByClassName(className: string): HTMLElement {
+        return this.getAllTypecastElementsByClassName(className)[0]
+    }
+
+    private setCustomStyles() {
+        if (!this.customStyles) return
+
+        const {
+            modalBackgroundColor,
+            logoBackgroundColor,
+            isLogoRound,
+            optionBackgroundColor,
+            optionFontColor,
+            primaryFontColor,
+            secondaryFontColor,
+            linkColor
+        } = this.customStyles
+
+        if (modalBackgroundColor) {
+            const walletSelectorInner = this.getTypecastElementByClassName('wallet-selector-inner')
+            const walletSelectorConnect = this.getTypecastElementByClassName('wallet-selector-connect')
+            walletSelectorInner.style.backgroundColor = modalBackgroundColor
+            walletSelectorConnect.style.backgroundColor = modalBackgroundColor
+        }
+        
+        if (logoBackgroundColor) {
+            const logo = this.getTypecastElementByClassName('wallet-selector-logo')
+            logo.style.backgroundColor = logoBackgroundColor
+            
+            if (isLogoRound) {
+                logo.style.width = '120px'
+                logo.style.height = '120px'
+                logo.style.padding = '10px'
+                logo.style.marginBottom = '10px'
+                logo.style.border = '1px solid rgba(161, 165, 176, 0.23)'
+                logo.style.borderRadius = '50%'
+            }
+        }
+        
+        if (optionBackgroundColor) {
+            const selectorOptions = Array.from(this.getTypecastElementByClassName('wallet-selector-wallet-list').children as HTMLCollectionOf<HTMLElement>)
+            for (const option of selectorOptions) {
+                option.style.backgroundColor = optionBackgroundColor
+            }
+        }
+        
+        if (optionFontColor) {
+            const selectorOptionNames = this.getAllTypecastElementsByClassName('wallet-selector-wallet-name')
+            for (const name of selectorOptionNames) {
+                name.style.color = optionFontColor
+            }
+        }
+        
+        if (primaryFontColor) {
+            const selectorTitle = this.getTypecastElementByClassName('wallet-selector-title')
+            selectorTitle.style.color = primaryFontColor
+        }
+        
+        if (secondaryFontColor) {
+            const selectorSubtitle = this.getTypecastElementByClassName('wallet-selector-subtitle')
+            const footerText = this.getTypecastElementByClassName('wallet-selector-tos-agreement')
+            selectorSubtitle.style.color = secondaryFontColor
+            footerText.style.color = secondaryFontColor
+        }
+        
+        if (linkColor) {
+            const termsOfServiceLink = this.getTypecastElementByClassName('wallet-selector-tos-link')
+            termsOfServiceLink.style.color = linkColor
+        }
     }
 }
 

--- a/packages/proton-web-sdk/src/supported-wallets.ts
+++ b/packages/proton-web-sdk/src/supported-wallets.ts
@@ -36,7 +36,9 @@ export default class SupportedWallets {
         this.font.rel = 'stylesheet';
         this.styleEl = document.createElement('style')
         this.styleEl.type = 'text/css'
-        this.styleEl.appendChild(document.createTextNode(styleText))
+
+        const customStyleText = this.getCustomStyleText()
+        this.styleEl.appendChild(document.createTextNode(styleText + customStyleText))
         this.styleEl.appendChild(this.font)
         document.head.appendChild(this.styleEl)
 
@@ -182,22 +184,12 @@ export default class SupportedWallets {
 
             this.selectorEl.appendChild(header)
             this.selectorEl.appendChild(body)
-            this.setCustomStyles()
             this.showSelector()
         })
     }
 
-    private getAllTypecastElementsByClassName(className: string): HTMLElement[] {
-        return Array.from(document.getElementsByClassName(className) as HTMLCollectionOf<HTMLElement>)
-    }
-
-    private getTypecastElementByClassName(className: string): HTMLElement {
-        return this.getAllTypecastElementsByClassName(className)[0]
-    }
-
-    private setCustomStyles() {
-        if (!this.customStyles) return
-
+    private getCustomStyleText(): string {
+        if (!this.customStyles) return ''
         const {
             modalBackgroundColor,
             logoBackgroundColor,
@@ -209,57 +201,65 @@ export default class SupportedWallets {
             linkColor
         } = this.customStyles
 
-        if (modalBackgroundColor) {
-            const walletSelectorInner = this.getTypecastElementByClassName('wallet-selector-inner')
-            const walletSelectorConnect = this.getTypecastElementByClassName('wallet-selector-connect')
-            walletSelectorInner.style.backgroundColor = modalBackgroundColor
-            walletSelectorConnect.style.backgroundColor = modalBackgroundColor
+        return `        
+        ${modalBackgroundColor && `
+        .wallet-selector-inner {
+            background: ${modalBackgroundColor};
         }
-        
-        if (logoBackgroundColor) {
-            const logo = this.getTypecastElementByClassName('wallet-selector-logo')
-            logo.style.backgroundColor = logoBackgroundColor
-            
-            if (isLogoRound) {
-                logo.style.width = '120px'
-                logo.style.height = '120px'
-                logo.style.padding = '10px'
-                logo.style.marginBottom = '10px'
-                logo.style.border = '1px solid rgba(161, 165, 176, 0.23)'
-                logo.style.borderRadius = '50%'
-            }
+
+        .wallet-selector-connect {
+            background: ${modalBackgroundColor};
         }
-        
-        if (optionBackgroundColor) {
-            const selectorOptions = Array.from(this.getTypecastElementByClassName('wallet-selector-wallet-list').children as HTMLCollectionOf<HTMLElement>)
-            for (const option of selectorOptions) {
-                option.style.backgroundColor = optionBackgroundColor
-            }
+        `}
+
+        ${logoBackgroundColor && `
+        .wallet-selector-logo {
+            background: ${logoBackgroundColor};
+            ${isLogoRound && `
+            width: 120px;
+            height: 120px;
+            padding: 10px;
+            margin-bottom: 10px;
+            border: 1px solid rgba(161, 165, 176, 0.23);
+            border-radius: 50%;
+            `}
         }
-        
-        if (optionFontColor) {
-            const selectorOptionNames = this.getAllTypecastElementsByClassName('wallet-selector-wallet-name')
-            for (const name of selectorOptionNames) {
-                name.style.color = optionFontColor
-            }
+        `}
+
+        ${optionBackgroundColor && `
+        .wallet-selector-wallet-list li {
+            background: ${optionBackgroundColor};
         }
-        
-        if (primaryFontColor) {
-            const selectorTitle = this.getTypecastElementByClassName('wallet-selector-title')
-            selectorTitle.style.color = primaryFontColor
+        `}
+
+        ${optionFontColor && `
+        .wallet-selector-wallet-name {
+            color: ${optionFontColor};
         }
-        
-        if (secondaryFontColor) {
-            const selectorSubtitle = this.getTypecastElementByClassName('wallet-selector-subtitle')
-            const footerText = this.getTypecastElementByClassName('wallet-selector-tos-agreement')
-            selectorSubtitle.style.color = secondaryFontColor
-            footerText.style.color = secondaryFontColor
+        `}
+
+        ${primaryFontColor && `
+        .wallet-selector-title {
+            color: ${primaryFontColor};
         }
-        
-        if (linkColor) {
-            const termsOfServiceLink = this.getTypecastElementByClassName('wallet-selector-tos-link')
-            termsOfServiceLink.style.color = linkColor
+        `}
+
+        ${secondaryFontColor && `
+        .wallet-selector-subtitle {
+            color: ${secondaryFontColor};
         }
+
+        .wallet-selector-tos-agreement {
+            color: ${secondaryFontColor};
+        }
+        `}
+
+        ${linkColor && `
+        .wallet-selector-tos-link {
+            color: ${linkColor};
+        }
+        `}
+        `
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,16 @@ const link = await ConnectWallet({
     selectorOptions: {
         appName: 'Taskly', /* Optional: Name to show in modal, Default 'app' */
         appLogo: 'https://protondemos.com/static/media/taskly-logo.ad0bfb0f.svg', /* Optional: Logo to show in modal */
+        customStyles: { /* Optional: Custom styles for modal */
+            modalBackgroundColor: '#F4F7FA',
+            logoBackgroundColor: 'white',
+            isLogoRound: true,
+            optionBackgroundColor: 'white',
+            optionFontColor: 'black',
+            primaryFontColor: 'black',
+            secondaryFontColor: '#6B727F',
+            linkColor: '#752EEB'
+        }
         // walletType: 'proton' /* Optional: Connect to only specified wallet (e.g. 'proton', 'anchor') */
     }
 })

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ const link = await ConnectWallet({
     selectorOptions: {
         appName: 'Taskly', /* Optional: Name to show in modal, Default 'app' */
         appLogo: 'https://protondemos.com/static/media/taskly-logo.ad0bfb0f.svg', /* Optional: Logo to show in modal */
-        customStyles: { /* Optional: Custom styles for modal */
+        customStyleOptions: { /* Optional: Custom style options for modal */
             modalBackgroundColor: '#F4F7FA',
             logoBackgroundColor: 'white',
             isLogoRound: true,


### PR DESCRIPTION
Example `customStyles` option:

```js
customStyles: {
  modalBackgroundColor: '#F4F7FA',
  logoBackgroundColor: 'white',
  isLogoRound: true,
  optionBackgroundColor: 'white',
  optionFontColor: 'black',
  primaryFontColor: 'black',
  secondaryFontColor: '#6B727F',
  linkColor: '#752EEB'
}
```

<img width="374" alt="Screen Shot 2020-12-04 at 1 46 02 PM" src="https://user-images.githubusercontent.com/32081352/101219779-5f9b9680-3639-11eb-8485-2d8b507beab4.png">
